### PR TITLE
testing Client support cookie

### DIFF
--- a/src/testing/src/Client.php
+++ b/src/testing/src/Client.php
@@ -221,8 +221,12 @@ class Client extends Server
         $body = new SwooleStream($content);
 
         $request = new Psr7Request($method, $uri, $headers, $body);
+        
+        $cookies = $headers['Cookie'] ?? [];
+        
         return $request->withQueryParams($query)
             ->withParsedBody($data)
+            ->withCookieParams($cookies)
             ->withUploadedFiles($this->normalizeFiles($multipart));
     }
 


### PR DESCRIPTION
testing Client support cookie, for examples:

$headers = [
    'Cookie' => [
        'PHP_SESSION_ID' => '12345678'
    ]
];
$this->client->get('/', [], $headers);